### PR TITLE
Fix reformatting bug

### DIFF
--- a/lib/TidyLst/Data.pm
+++ b/lib/TidyLst/Data.pm
@@ -1318,7 +1318,7 @@ our %masterOrder = (
    ],
 
    'GLOBALMODIFIER' => [
-      '000GlobalmonName',
+      '000GlobalmodName',
       'EXPLANATION',
    ],
 


### PR DESCRIPTION
SUB lines in biosettings were not getting their own formatter.
This caused them to be blank.

Refactored the calculation of required padding out to a seaparete
operation which is called in multiple places.

Added logic to ensure that all of the lines that are First column
formatted have the smae first column length throughout a file (looks
neater).